### PR TITLE
added dtlz and gcc examples

### DIFF
--- a/examples/dtlz/dtlz.py
+++ b/examples/dtlz/dtlz.py
@@ -1,0 +1,129 @@
+import sys
+import math
+import xml.dom.minidom as minidom
+#import os
+#import os.path
+import getopt
+import time
+
+# Files
+inpFname_XML = None
+outFname_XML = None
+
+
+def main():
+
+    # Read input variables
+    x1 = -1
+    x2 = -1
+    x3 = -1
+
+    doc2 = minidom.parse(inpFname_XML)
+    params = doc2.getElementsByTagName("parameter")
+    for param in params:
+        name = param.getAttribute("name")
+        if name in ['x1', 'x2', 'x3']:
+            if name == 'x1':
+                x1 = float(param.getAttribute("value"))/10
+            elif name == 'x2':
+                x2 = float(param.getAttribute("value"))/10
+            elif name == 'x3':
+                x3 = float(param.getAttribute("value"))/10
+
+    if x1 == -1 or x2 == -1 or x3 == -1:
+        error_executing_script("Missing input variables")
+
+    sum_xi = (math.pow(x1 - 0.5, 2) - math.cos(20 * math.pi * (x1 - 0.5)))
+    sum_xi = sum_xi + (math.pow(x2 - 0.5, 2) -
+                       math.cos(20 * math.pi * (x2 - 0.5)))
+    sum_xi = sum_xi + (math.pow(x3 - 0.5, 2) -
+                       math.cos(20 * math.pi * (x3 - 0.5)))
+
+    gx = 100 * (3 + sum_xi)
+
+    f1 = 0.5 * x1 * x2 * (1 + gx)
+    f2 = 0.5 * x1 * (1 - x2) * (1 + gx)
+    f3 = 0.5 * (1 - x1) * (1 + gx)
+
+    doc = minidom.Document()
+    root = doc.createElementNS(
+        "http://www.multicube.eu/", "simulator_output_interface")
+    root.setAttribute("xmlns", "http://www.multicube.eu/")
+    root.setAttribute("version", "1.3")
+    doc.appendChild(root)
+
+    # Write functions f1, f2 and f3 in XML file to send their value to the M3Explorer
+    metricNode = doc.createElement("system_metric")
+    metricNode.setAttribute("name", "f1")
+    metricNode.setAttribute("value", str(f1))
+    root.appendChild(metricNode)
+
+    metricNode = doc.createElement("system_metric")
+    metricNode.setAttribute("name", "f2")
+    metricNode.setAttribute("value", str(f2))
+    root.appendChild(metricNode)
+
+    metricNode = doc.createElement("system_metric")
+    metricNode.setAttribute("name", "f3")
+    metricNode.setAttribute("value", str(f3))
+    root.appendChild(metricNode)
+
+    outputString = doc.toprettyxml()
+    doc.unlink()
+    f = open(outFname_XML, "w")
+    f.write(outputString)
+    f.close()
+
+
+def error_executing_script(error_text):
+    print(" "+error_text+" ")
+
+    doc = minidom.Document()
+    root = doc.createElementNS(
+        "http://www.multicube.eu/", "simulator_output_interface")
+    root.setAttribute("xmlns", "http://www.multicube.eu/")
+    root.setAttribute("version", "1.3")
+    doc.appendChild(root)
+
+    errorNode = doc.createElement("error")
+    errorNode.setAttribute("reason", error_text)
+    errorNode.setAttribute("kind", "fatal")
+    root.appendChild(errorNode)
+
+    outputString = doc.toprettyxml()
+    doc.unlink()
+    f = open(outFname_XML, "w")
+    f.write(outputString)
+    f.close()
+    sys.exit(1)
+
+
+def usage(program):
+    print("Usage: "+program+" --xml_system_configuration=input_filename.xml --xml_system_metrics=output_filename.xml --reference_xsd=input_filename.xsd")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "", [
+                                   "xml_system_configuration=", "xml_system_metrics=", "reference_xsd="])
+    except getopt.GetoptError as err:
+        print(err)
+        usage(sys.argv[0])
+    for o, a in opts:
+        if o == "--xml_system_configuration":
+            inpFname_XML = a
+        elif o == "--xml_system_metrics":
+            outFname_XML = a
+        elif o == "--reference_xsd":
+            pass
+        else:
+            usage(sys.argv[0])
+
+    if(inpFname_XML == None or outFname_XML == None):
+        usage(sys.argv[0])
+
+    # Initialization
+
+    main()
+    sys.exit(0)

--- a/examples/dtlz/dtlz_dse.xml
+++ b/examples/dtlz/dtlz_dse.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<design_space xmlns="http://www.multicube.eu/" version="1.3">
+    <simulator>
+        <simulator_executable path="python /path/to/most/examples/dtlz/dtlz.py" />
+    </simulator>
+    <parameters>
+	<parameter name="x1" type="integer" min="0" max="10" step="1" />
+	<parameter name="x2" type="integer" min="0" max="10" step="1" />
+	<parameter name="x3" type="integer" min="0" max="10" step="1" />
+    </parameters>
+    <system_metrics>
+	<system_metric name="f1" type="float" unit="" desired="small" />
+	<system_metric name="f2" type="float" unit="" desired="small" />
+	<system_metric name="f3" type="float" unit="" desired="small" />
+    </system_metrics>
+</design_space>

--- a/examples/dtlz/dtlz_fullsearch.scr
+++ b/examples/dtlz/dtlz_fullsearch.scr
@@ -1,0 +1,24 @@
+# Here are the declaration of the objective functions
+# objectives are the goal for the optimization step
+# f1, f2, f3 are metrics defined in the DS
+
+# Step 1. set the objectives for each design x
+
+set_objective obj_a(x) = f1($x)
+set_objective obj_b(x) = f2($x)
+set_objective obj_c(x) = f3($x)
+
+# Step 2. Define an initial Doe and an optimizer.
+# Here, the optimizer just executes the defined Doe, nothing else
+
+doe_load_doe "st_full_search"
+opt_load_optimizer "st_parallel_doe"
+
+# Step 3. Invoke the optimizer and write designs and metrics into FULL_DB (database)
+opt_tune FULL_DB
+
+# Step 4. Filter out non-dominant configurations considering also the constraints
+db_filter_pareto FULL_DB --valid=TRUE
+
+# Optionally Export of all the simulation results in a CSV file
+db_export FULL_DB --file_name=all.csv

--- a/examples/dtlz/readme.md
+++ b/examples/dtlz/readme.md
@@ -1,0 +1,15 @@
+# DTLZ1 Optimization problem Example  
+A box-constrained continuous n-dimensional n-objective problem with a linear Pareto-optimal front. [More details here](https://pymoo.org/problems/many/dtlz.html)  
+In this example, *n* = 3: the design space has 3 dimensions (*x1, x2, x3*) and 3 objectives (*f1, f2, f3*) to minimize.
+
+## Integer representation of the design space
+While the original DTLZ1 problem is based on a continuous design space (in which *x1, x2, x3* can take real values in the interval [0, 1]), in this example we provide an integer formulation of the design space (in the file *dtlz_dse.xml*): the three variables (*x1, x2, x3*) are represented as integers whose values can span between 0 and 10.  
+
+The python script *dtlz.py* is the *Use Case Simulator* : it parses the values of *x1, x2, x3* from the XML produced by *MOST*, converts them to *float* values in the interval [0, 1] (by dividing them by 10), computes the output metrics *f1, f2, f3* and writes them to the output XML.
+
+## Launch a full (integer) search
+The script *dtlz_fullsearch.scr* implements a simple full search strategy on the integer design space, and performs pareto filtering on the final results.  
+It can be launched with the following command:  
+
+    most -x dtlz_dse.xml -f dtlz_fullsearch.scr  
+Befaure launching the example, please modify the *simulator_executable path* in *dtlz_dse.xml*.  

--- a/examples/gcc/gcc_ds.xml
+++ b/examples/gcc/gcc_ds.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<design_space xmlns="http://www.multicube.eu/" version="1.3">
+<simulator>
+        <simulator_executable path="python /path/to/most/examples/gcc/gcc_most.py --file=linpack.c" />
+</simulator>
+<parameters>
+<parameter name="par_opt" type="string">
+    <item value="-O"/>
+    <item value="-O0"/>
+    <item value="-O1"/>
+    <item value="-O2"/>
+    <item value="-O3"/>
+    <item value="-Os"/>
+</parameter>
+<parameter name="par_dbg" type="string">
+    <item value=" "/>
+    <item value="-g"/>
+</parameter>
+</parameters>
+<system_metrics>
+        <system_metric name="compilation_time" type="float" unit="sec" desired="small" />
+        <system_metric name="execution_time" type="float" unit="sec" desired="small" />
+        <system_metric name="code_size" type="float" unit="Byte" desired="small" />
+</system_metrics>
+</design_space>

--- a/examples/gcc/gcc_full_dse.scr
+++ b/examples/gcc/gcc_full_dse.scr
@@ -1,0 +1,25 @@
+# Here are the declaration of the objective functions
+# objectives are the goal for the optimization step
+# Execution_time and code size are metrics defined in the DS
+
+# Step 1. set the objectives for each design x
+
+set_objective obj_a(x) = execution_time($x)
+set_objective obj_b(x) = code_size($x)
+
+# Step 2. Define an initial Doe and an optimizer.
+# Here, the optimizer just executes the defined Doe, nothing else
+
+doe_load_doe "st_full_search"
+opt_load_optimizer "st_parallel_doe"
+
+
+# Step 3. Invoke the optimizer and write designs and metrics into FULL_DB (database)
+opt_tune FULL_DB
+
+# Step 4. Filter out non-dominant configurations considering also the constraints
+db_filter_pareto FULL_DB --valid=TRUE
+
+# Optionally Export of all the simulation results in a CSV file
+db_write FULL_DB --file_name=gcc.db
+db_export FULL_DB --file_name=all.csv

--- a/examples/gcc/gcc_most.py
+++ b/examples/gcc/gcc_most.py
@@ -1,0 +1,117 @@
+# Stub simulator for m3explorer; it creates the correct output XML document,
+# multiplying some of the given parameters as output metrics.
+# This script expects two parameters, as a specific:
+# --xml_system_configuration=input_filename.xml
+# --xml_system_metrics=output_filename.xml
+#
+# @author Sivieri Alessandro
+
+import xml.dom.minidom as minidom
+import os.path
+import os
+import time
+import sys
+import getopt
+
+# parameters
+par_opt = 0
+par_dbg = 0
+par_opt_bool = False
+par_dbg_bool = False
+# files
+outputFilename = None
+inputFilename = None
+
+
+def main():
+    # reading input params
+    doc2 = minidom.parse(inputFilename)
+    params = doc2.getElementsByTagName("parameter")
+    for param in params:
+        name = param.getAttribute("name")
+        if name == "par_opt":
+            par_opt = param.getAttribute("value")
+            par_opt_bool = True
+        if name == "par_dbg":
+            par_dbg = param.getAttribute("value")
+            par_dbg_bool = True
+    # writing output params
+    doc = minidom.Document()
+    root = doc.createElementNS(
+        "http://www.multicube.eu/", "simulator_output_interface")
+    root.setAttribute("xmlns", "http://www.multicube.eu/")
+    root.setAttribute("version", "1.3")
+    doc.appendChild(root)
+    base_dir_executable = os.path.dirname(sys.argv[0])
+    base_dir_intermediate_files = os.getcwd()
+    if not par_opt_bool or not par_dbg_bool:
+        # error output
+        errorNode = doc.createElement("error")
+        errorNode.setAttribute("reason", "missing required parameter")
+        errorNode.setAttribute("kind", "fatal")
+        root.appendChild(errorNode)
+    else:
+        # metric1
+        node = doc.createElement("system_metric")
+        node.setAttribute("name", "compilation_time")
+        t0 = time.time()
+        command = "gcc "+ par_opt + " " + par_dbg + " " + base_dir_executable + \
+            "/" + targetFilename + " -o " + \
+            base_dir_intermediate_files + "/test.out"
+        print("--> " + command + " ")
+        os.system(command)
+        t1 = time.time()-t0
+        node.setAttribute("value", str(t1))
+        root.appendChild(node)
+        # metric2
+        node = doc.createElement("system_metric")
+        node.setAttribute("name", "code_size")
+        executable_file = base_dir_intermediate_files + "/test.out"
+        code_size = os.path.getsize(executable_file)
+        node.setAttribute("value", str(code_size))
+        root.appendChild(node)
+    # metric3
+        node = doc.createElement("system_metric")
+        node.setAttribute("name", "execution_time")
+        t0 = time.time()
+        os.system(executable_file)
+        t1 = time.time()-t0
+        node.setAttribute("value", str(t1))
+        root.appendChild(node)
+
+# writing output in the same directory of input
+    outputString = doc.toprettyxml()
+    doc.unlink()
+    f = open(outputFilename, "w")
+    f.write(outputString)
+    f.close()
+#	time.sleep(1.5)
+
+
+def usage(program):
+    print("Usage: "+program+" --file=target_filename.c --xml_system_configuration=input_filename.xml --xml_system_metrics=output_filename.xml --reference_xsd=input_filename.xsd")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "", [
+                                   "xml_system_configuration=", "xml_system_metrics=", "reference_xsd=", "file="])
+    except getopt.GetoptError as err:
+        print(err)
+        usage(sys.argv[0])
+    for o, a in opts:
+        if o == "--xml_system_configuration":
+            inputFilename = a
+        elif o == "--xml_system_metrics":
+            outputFilename = a
+        elif o == "--file":
+            targetFilename = a
+        elif o == "--reference_xsd":
+            pass
+        else:
+            usage(sys.argv[0])
+    if(inputFilename == None or outputFilename == None or targetFilename == None):
+        usage(sys.argv[0])
+    main()
+    sys.exit(0)

--- a/examples/gcc/linpack.c
+++ b/examples/gcc/linpack.c
@@ -1,0 +1,880 @@
+/*
+**
+** LINPACK.C        Linpack benchmark, calculates FLOPS.
+**                  (FLoating Point Operations Per Second)
+**
+** Translated to C by Bonnie Toy 5/88
+**
+** Modified by Will Menninger, 10/93, with these features:
+**  (modified on 2/25/94  to fix a problem with daxpy  for
+**   unequal increments or equal increments not equal to 1.
+**     Jack Dongarra)
+**
+** - Defaults to double precision.
+** - Averages ROLLed and UNROLLed performance.
+** - User selectable array sizes.
+** - Automatically does enough repetitions to take at least 10 CPU seconds.
+** - Prints machine precision.
+** - ANSI prototyping.
+**
+** To compile:  cc -O -o linpack linpack.c -lm
+**
+**
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <time.h>
+#include <float.h>
+
+#define DP
+
+#ifdef SP
+#define ZERO        0.0
+#define ONE         1.0
+#define PREC        "Single"
+#define BASE10DIG   FLT_DIG
+
+typedef float   REAL;
+#endif
+
+#ifdef DP
+#define ZERO        0.0e0
+#define ONE         1.0e0
+#define PREC        "Double"
+#define BASE10DIG   DBL_DIG
+
+typedef double  REAL;
+#endif
+
+#define MAX_TIME_FOR_TEST 5.0
+
+
+static REAL linpack  (long nreps,int arsize);
+static void matgen   (REAL *a,int lda,int n,REAL *b,REAL *norma);
+static void dgefa    (REAL *a,int lda,int n,int *ipvt,int *info,int roll);
+static void dgesl    (REAL *a,int lda,int n,int *ipvt,REAL *b,int job,int roll);
+static void daxpy_r  (int n,REAL da,REAL *dx,int incx,REAL *dy,int incy);
+static REAL ddot_r   (int n,REAL *dx,int incx,REAL *dy,int incy);
+static void dscal_r  (int n,REAL da,REAL *dx,int incx);
+static void daxpy_ur (int n,REAL da,REAL *dx,int incx,REAL *dy,int incy);
+static REAL ddot_ur  (int n,REAL *dx,int incx,REAL *dy,int incy);
+static void dscal_ur (int n,REAL da,REAL *dx,int incx);
+static int  idamax   (int n,REAL *dx,int incx);
+static REAL second   (void);
+
+static void *mempool;
+
+
+int main(void)
+{
+    char    *arsize_input;
+    int     arsize;
+    long    arsize2d,nreps;
+    size_t  malloc_arg,memreq;
+
+    arsize_input = getenv("LINPACK_ARRAY_SIZE");
+    if (arsize_input == NULL) {
+        arsize = 200;
+    } else {
+        arsize = atoi(arsize_input);
+    }
+
+        arsize/=2;
+        arsize*=2;
+        if (arsize<10)
+            {
+            printf("Too small.\n");
+            return 1;
+            }
+        arsize2d = (long)arsize*(long)arsize;
+        memreq=arsize2d*sizeof(REAL)+(long)arsize*sizeof(REAL)+(long)arsize*sizeof(int);
+        printf("Memory required:  %ldK.\n",(memreq+512L)>>10);
+        malloc_arg=(size_t)memreq;
+        if (malloc_arg!=memreq || (mempool=malloc(malloc_arg))==NULL)
+            {
+            printf("Not enough memory available for given array size.\n\n");
+            return 2;
+            }
+        printf("\n\nLINPACK benchmark, %s precision.\n",PREC);
+        printf("Machine precision:  %d digits.\n",BASE10DIG);
+        printf("Array size %d X %d.\n",arsize,arsize);
+        printf("Average rolled and unrolled performance:\n\n");
+        printf("    Reps Time(s) DGEFA   DGESL  OVERHEAD    KFLOPS\n");
+        printf("----------------------------------------------------\n");
+        nreps=1;
+        while (linpack(nreps,arsize) < MAX_TIME_FOR_TEST)
+            nreps*=2;
+        free(mempool);
+        printf("\n");
+}
+
+
+static REAL linpack(long nreps,int arsize)
+
+    {
+    REAL  *a,*b;
+    REAL   norma,t1,kflops,tdgesl,tdgefa,totalt,toverhead,ops;
+    int   *ipvt,n,info,lda;
+    long   i,arsize2d;
+
+    lda = arsize;
+    n = arsize/2;
+    arsize2d = (long)arsize*(long)arsize;
+    ops=((2.0*n*n*n)/3.0+2.0*n*n);
+    a=(REAL *)mempool;
+    b=a+arsize2d;
+    ipvt=(int *)&b[arsize];
+    tdgesl=0;
+    tdgefa=0;
+    totalt=second();
+    for (i=0;i<nreps;i++)
+        {
+        matgen(a,lda,n,b,&norma);
+        t1 = second();
+        dgefa(a,lda,n,ipvt,&info,1);
+        tdgefa += second()-t1;
+        t1 = second();
+        dgesl(a,lda,n,ipvt,b,0,1);
+        tdgesl += second()-t1;
+        }
+    for (i=0;i<nreps;i++)
+        {
+        matgen(a,lda,n,b,&norma);
+        t1 = second();
+        dgefa(a,lda,n,ipvt,&info,0);
+        tdgefa += second()-t1;
+        t1 = second();
+        dgesl(a,lda,n,ipvt,b,0,0);
+        tdgesl += second()-t1;
+        }
+    totalt=second()-totalt;
+    if (totalt<0.5 || tdgefa+tdgesl<0.2)
+        return(0.);
+    kflops=2.*nreps*ops/(1000.*(tdgefa+tdgesl));
+    toverhead=totalt-tdgefa-tdgesl;
+    if (tdgefa<0.)
+        tdgefa=0.;
+    if (tdgesl<0.)
+        tdgesl=0.;
+    if (toverhead<0.)
+        toverhead=0.;
+    printf("%8ld %6.2f %6.2f%% %6.2f%% %6.2f%%  %9.3f\n",
+            nreps,totalt,100.*tdgefa/totalt,
+            100.*tdgesl/totalt,100.*toverhead/totalt,
+            kflops);
+    return(totalt);
+    }
+
+
+/*
+** For matgen,
+** We would like to declare a[][lda], but c does not allow it.  In this
+** function, references to a[i][j] are written a[lda*i+j].
+*/
+static void matgen(REAL *a,int lda,int n,REAL *b,REAL *norma)
+
+    {
+    int init,i,j;
+
+    init = 1325;
+    *norma = 0.0;
+    for (j = 0; j < n; j++)
+        for (i = 0; i < n; i++)
+            {
+            init = (int)((long)3125*(long)init % 65536L);
+            a[lda*j+i] = (init - 32768.0)/16384.0;
+            *norma = (a[lda*j+i] > *norma) ? a[lda*j+i] : *norma;
+            }
+    for (i = 0; i < n; i++)
+        b[i] = 0.0;
+    for (j = 0; j < n; j++)
+        for (i = 0; i < n; i++)
+            b[i] = b[i] + a[lda*j+i];
+    }
+
+
+/*
+**
+** DGEFA benchmark
+**
+** We would like to declare a[][lda], but c does not allow it.  In this
+** function, references to a[i][j] are written a[lda*i+j].
+**
+**   dgefa factors a double precision matrix by gaussian elimination.
+**
+**   dgefa is usually called by dgeco, but it can be called
+**   directly with a saving in time if  rcond  is not needed.
+**   (time for dgeco) = (1 + 9/n)*(time for dgefa) .
+**
+**   on entry
+**
+**      a       REAL precision[n][lda]
+**              the matrix to be factored.
+**
+**      lda     integer
+**              the leading dimension of the array  a .
+**
+**      n       integer
+**              the order of the matrix  a .
+**
+**   on return
+**
+**      a       an upper triangular matrix and the multipliers
+**              which were used to obtain it.
+**              the factorization can be written  a = l*u  where
+**              l  is a product of permutation and unit lower
+**              triangular matrices and  u  is upper triangular.
+**
+**      ipvt    integer[n]
+**              an integer vector of pivot indices.
+**
+**      info    integer
+**              = 0  normal value.
+**              = k  if  u[k][k] .eq. 0.0 .  this is not an error
+**                   condition for this subroutine, but it does
+**                   indicate that dgesl or dgedi will divide by zero
+**                   if called.  use  rcond  in dgeco for a reliable
+**                   indication of singularity.
+**
+**   linpack. this version dated 08/14/78 .
+**   cleve moler, university of New Mexico, argonne national lab.
+**
+**   functions
+**
+**   blas daxpy,dscal,idamax
+**
+*/
+static void dgefa(REAL *a,int lda,int n,int *ipvt,int *info,int roll)
+
+    {
+    REAL t;
+    int idamax(),j,k,kp1,l,nm1;
+
+    /* gaussian elimination with partial pivoting */
+
+    if (roll)
+        {
+        *info = 0;
+        nm1 = n - 1;
+        if (nm1 >=  0)
+            for (k = 0; k < nm1; k++)
+                {
+                kp1 = k + 1;
+
+                /* find l = pivot index */
+
+                l = idamax(n-k,&a[lda*k+k],1) + k;
+                ipvt[k] = l;
+
+                /* zero pivot implies this column already
+                   triangularized */
+
+                if (a[lda*k+l] != ZERO)
+                    {
+
+                    /* interchange if necessary */
+
+                    if (l != k)
+                        {
+                        t = a[lda*k+l];
+                        a[lda*k+l] = a[lda*k+k];
+                        a[lda*k+k] = t;
+                        }
+
+                    /* compute multipliers */
+
+                    t = -ONE/a[lda*k+k];
+                    dscal_r(n-(k+1),t,&a[lda*k+k+1],1);
+
+                    /* row elimination with column indexing */
+
+                    for (j = kp1; j < n; j++)
+                        {
+                        t = a[lda*j+l];
+                        if (l != k)
+                            {
+                            a[lda*j+l] = a[lda*j+k];
+                            a[lda*j+k] = t;
+                            }
+                        daxpy_r(n-(k+1),t,&a[lda*k+k+1],1,&a[lda*j+k+1],1);
+                        }
+                    }
+                else
+                    (*info) = k;
+                }
+        ipvt[n-1] = n-1;
+        if (a[lda*(n-1)+(n-1)] == ZERO)
+            (*info) = n-1;
+        }
+    else
+        {
+        *info = 0;
+        nm1 = n - 1;
+        if (nm1 >=  0)
+            for (k = 0; k < nm1; k++)
+                {
+                kp1 = k + 1;
+
+                /* find l = pivot index */
+
+                l = idamax(n-k,&a[lda*k+k],1) + k;
+                ipvt[k] = l;
+
+                /* zero pivot implies this column already
+                   triangularized */
+
+                if (a[lda*k+l] != ZERO)
+                    {
+
+                    /* interchange if necessary */
+
+                    if (l != k)
+                        {
+                        t = a[lda*k+l];
+                        a[lda*k+l] = a[lda*k+k];
+                        a[lda*k+k] = t;
+                        }
+
+                    /* compute multipliers */
+
+                    t = -ONE/a[lda*k+k];
+                    dscal_ur(n-(k+1),t,&a[lda*k+k+1],1);
+
+                    /* row elimination with column indexing */
+
+                    for (j = kp1; j < n; j++)
+                        {
+                        t = a[lda*j+l];
+                        if (l != k)
+                            {
+                            a[lda*j+l] = a[lda*j+k];
+                            a[lda*j+k] = t;
+                            }
+                        daxpy_ur(n-(k+1),t,&a[lda*k+k+1],1,&a[lda*j+k+1],1);
+                        }
+                    }
+                else
+                    (*info) = k;
+                }
+        ipvt[n-1] = n-1;
+        if (a[lda*(n-1)+(n-1)] == ZERO)
+            (*info) = n-1;
+        }
+    }
+
+
+/*
+**
+** DGESL benchmark
+**
+** We would like to declare a[][lda], but c does not allow it.  In this
+** function, references to a[i][j] are written a[lda*i+j].
+**
+**   dgesl solves the double precision system
+**   a * x = b  or  trans(a) * x = b
+**   using the factors computed by dgeco or dgefa.
+**
+**   on entry
+**
+**      a       double precision[n][lda]
+**              the output from dgeco or dgefa.
+**
+**      lda     integer
+**              the leading dimension of the array  a .
+**
+**      n       integer
+**              the order of the matrix  a .
+**
+**      ipvt    integer[n]
+**              the pivot vector from dgeco or dgefa.
+**
+**      b       double precision[n]
+**              the right hand side vector.
+**
+**      job     integer
+**              = 0         to solve  a*x = b ,
+**              = nonzero   to solve  trans(a)*x = b  where
+**                          trans(a)  is the transpose.
+**
+**  on return
+**
+**      b       the solution vector  x .
+**
+**   error condition
+**
+**      a division by zero will occur if the input factor contains a
+**      zero on the diagonal.  technically this indicates singularity
+**      but it is often caused by improper arguments or improper
+**      setting of lda .  it will not occur if the subroutines are
+**      called correctly and if dgeco has set rcond .gt. 0.0
+**      or dgefa has set info .eq. 0 .
+**
+**   to compute  inverse(a) * c  where  c  is a matrix
+**   with  p  columns
+**         dgeco(a,lda,n,ipvt,rcond,z)
+**         if (!rcond is too small){
+**              for (j=0,j<p,j++)
+**                      dgesl(a,lda,n,ipvt,c[j][0],0);
+**         }
+**
+**   linpack. this version dated 08/14/78 .
+**   cleve moler, university of new mexico, argonne national lab.
+**
+**   functions
+**
+**   blas daxpy,ddot
+*/
+static void dgesl(REAL *a,int lda,int n,int *ipvt,REAL *b,int job,int roll)
+
+    {
+    REAL    t;
+    int     k,kb,l,nm1;
+
+    if (roll)
+        {
+        nm1 = n - 1;
+        if (job == 0)
+            {
+
+            /* job = 0 , solve  a * x = b   */
+            /* first solve  l*y = b         */
+
+            if (nm1 >= 1)
+                for (k = 0; k < nm1; k++)
+                    {
+                    l = ipvt[k];
+                    t = b[l];
+                    if (l != k)
+                        {
+                        b[l] = b[k];
+                        b[k] = t;
+                        }
+                    daxpy_r(n-(k+1),t,&a[lda*k+k+1],1,&b[k+1],1);
+                    }
+
+            /* now solve  u*x = y */
+
+            for (kb = 0; kb < n; kb++)
+                {
+                k = n - (kb + 1);
+                b[k] = b[k]/a[lda*k+k];
+                t = -b[k];
+                daxpy_r(k,t,&a[lda*k+0],1,&b[0],1);
+                }
+            }
+        else
+            {
+
+            /* job = nonzero, solve  trans(a) * x = b  */
+            /* first solve  trans(u)*y = b             */
+
+            for (k = 0; k < n; k++)
+                {
+                t = ddot_r(k,&a[lda*k+0],1,&b[0],1);
+                b[k] = (b[k] - t)/a[lda*k+k];
+                }
+
+            /* now solve trans(l)*x = y     */
+
+            if (nm1 >= 1)
+                for (kb = 1; kb < nm1; kb++)
+                    {
+                    k = n - (kb+1);
+                    b[k] = b[k] + ddot_r(n-(k+1),&a[lda*k+k+1],1,&b[k+1],1);
+                    l = ipvt[k];
+                    if (l != k)
+                        {
+                        t = b[l];
+                        b[l] = b[k];
+                        b[k] = t;
+                        }
+                    }
+            }
+        }
+    else
+        {
+        nm1 = n - 1;
+        if (job == 0)
+            {
+
+            /* job = 0 , solve  a * x = b   */
+            /* first solve  l*y = b         */
+
+            if (nm1 >= 1)
+                for (k = 0; k < nm1; k++)
+                    {
+                    l = ipvt[k];
+                    t = b[l];
+                    if (l != k)
+                        {
+                        b[l] = b[k];
+                        b[k] = t;
+                        }
+                    daxpy_ur(n-(k+1),t,&a[lda*k+k+1],1,&b[k+1],1);
+                    }
+
+            /* now solve  u*x = y */
+
+            for (kb = 0; kb < n; kb++)
+                {
+                k = n - (kb + 1);
+                b[k] = b[k]/a[lda*k+k];
+                t = -b[k];
+                daxpy_ur(k,t,&a[lda*k+0],1,&b[0],1);
+                }
+            }
+        else
+            {
+
+            /* job = nonzero, solve  trans(a) * x = b  */
+            /* first solve  trans(u)*y = b             */
+
+            for (k = 0; k < n; k++)
+                {
+                t = ddot_ur(k,&a[lda*k+0],1,&b[0],1);
+                b[k] = (b[k] - t)/a[lda*k+k];
+                }
+
+            /* now solve trans(l)*x = y     */
+
+            if (nm1 >= 1)
+                for (kb = 1; kb < nm1; kb++)
+                    {
+                    k = n - (kb+1);
+                    b[k] = b[k] + ddot_ur(n-(k+1),&a[lda*k+k+1],1,&b[k+1],1);
+                    l = ipvt[k];
+                    if (l != k)
+                        {
+                        t = b[l];
+                        b[l] = b[k];
+                        b[k] = t;
+                        }
+                    }
+            }
+        }
+    }
+
+
+
+/*
+** Constant times a vector plus a vector.
+** Jack Dongarra, linpack, 3/11/78.
+** ROLLED version
+*/
+static void daxpy_r(int n,REAL da,REAL *dx,int incx,REAL *dy,int incy)
+
+    {
+    int i,ix,iy;
+
+    if (n <= 0)
+        return;
+    if (da == ZERO)
+        return;
+
+    if (incx != 1 || incy != 1)
+        {
+
+        /* code for unequal increments or equal increments != 1 */
+
+        ix = 1;
+        iy = 1;
+        if(incx < 0) ix = (-n+1)*incx + 1;
+        if(incy < 0)iy = (-n+1)*incy + 1;
+        for (i = 0;i < n; i++)
+            {
+            dy[iy] = dy[iy] + da*dx[ix];
+            ix = ix + incx;
+            iy = iy + incy;
+            }
+        return;
+        }
+
+    /* code for both increments equal to 1 */
+
+    for (i = 0;i < n; i++)
+        dy[i] = dy[i] + da*dx[i];
+    }
+
+
+/*
+** Forms the dot product of two vectors.
+** Jack Dongarra, linpack, 3/11/78.
+** ROLLED version
+*/
+static REAL ddot_r(int n,REAL *dx,int incx,REAL *dy,int incy)
+
+    {
+    REAL dtemp;
+    int i,ix,iy;
+
+    dtemp = ZERO;
+
+    if (n <= 0)
+        return(ZERO);
+
+    if (incx != 1 || incy != 1)
+        {
+
+        /* code for unequal increments or equal increments != 1 */
+
+        ix = 0;
+        iy = 0;
+        if (incx < 0) ix = (-n+1)*incx;
+        if (incy < 0) iy = (-n+1)*incy;
+        for (i = 0;i < n; i++)
+            {
+            dtemp = dtemp + dx[ix]*dy[iy];
+            ix = ix + incx;
+            iy = iy + incy;
+            }
+        return(dtemp);
+        }
+
+    /* code for both increments equal to 1 */
+
+    for (i=0;i < n; i++)
+        dtemp = dtemp + dx[i]*dy[i];
+    return(dtemp);
+    }
+
+
+/*
+** Scales a vector by a constant.
+** Jack Dongarra, linpack, 3/11/78.
+** ROLLED version
+*/
+static void dscal_r(int n,REAL da,REAL *dx,int incx)
+
+    {
+    int i,nincx;
+
+    if (n <= 0)
+        return;
+    if (incx != 1)
+        {
+
+        /* code for increment not equal to 1 */
+
+        nincx = n*incx;
+        for (i = 0; i < nincx; i = i + incx)
+            dx[i] = da*dx[i];
+        return;
+        }
+
+    /* code for increment equal to 1 */
+
+    for (i = 0; i < n; i++)
+        dx[i] = da*dx[i];
+    }
+
+
+/*
+** constant times a vector plus a vector.
+** Jack Dongarra, linpack, 3/11/78.
+** UNROLLED version
+*/
+static void daxpy_ur(int n,REAL da,REAL *dx,int incx,REAL *dy,int incy)
+
+    {
+    int i,ix,iy,m;
+
+    if (n <= 0)
+        return;
+    if (da == ZERO)
+        return;
+
+    if (incx != 1 || incy != 1)
+        {
+
+        /* code for unequal increments or equal increments != 1 */
+
+        ix = 1;
+        iy = 1;
+        if(incx < 0) ix = (-n+1)*incx + 1;
+        if(incy < 0)iy = (-n+1)*incy + 1;
+        for (i = 0;i < n; i++)
+            {
+            dy[iy] = dy[iy] + da*dx[ix];
+            ix = ix + incx;
+            iy = iy + incy;
+            }
+        return;
+        }
+
+    /* code for both increments equal to 1 */
+
+    m = n % 4;
+    if ( m != 0)
+        {
+        for (i = 0; i < m; i++)
+            dy[i] = dy[i] + da*dx[i];
+        if (n < 4)
+            return;
+        }
+    for (i = m; i < n; i = i + 4)
+        {
+        dy[i] = dy[i] + da*dx[i];
+        dy[i+1] = dy[i+1] + da*dx[i+1];
+        dy[i+2] = dy[i+2] + da*dx[i+2];
+        dy[i+3] = dy[i+3] + da*dx[i+3];
+        }
+    }
+
+
+/*
+** Forms the dot product of two vectors.
+** Jack Dongarra, linpack, 3/11/78.
+** UNROLLED version
+*/
+static REAL ddot_ur(int n,REAL *dx,int incx,REAL *dy,int incy)
+
+    {
+    REAL dtemp;
+    int i,ix,iy,m;
+
+    dtemp = ZERO;
+
+    if (n <= 0)
+        return(ZERO);
+
+    if (incx != 1 || incy != 1)
+        {
+
+        /* code for unequal increments or equal increments != 1 */
+
+        ix = 0;
+        iy = 0;
+        if (incx < 0) ix = (-n+1)*incx;
+        if (incy < 0) iy = (-n+1)*incy;
+        for (i = 0;i < n; i++)
+            {
+            dtemp = dtemp + dx[ix]*dy[iy];
+            ix = ix + incx;
+            iy = iy + incy;
+            }
+        return(dtemp);
+        }
+
+    /* code for both increments equal to 1 */
+
+    m = n % 5;
+    if (m != 0)
+        {
+        for (i = 0; i < m; i++)
+            dtemp = dtemp + dx[i]*dy[i];
+        if (n < 5)
+            return(dtemp);
+        }
+    for (i = m; i < n; i = i + 5)
+        {
+        dtemp = dtemp + dx[i]*dy[i] +
+        dx[i+1]*dy[i+1] + dx[i+2]*dy[i+2] +
+        dx[i+3]*dy[i+3] + dx[i+4]*dy[i+4];
+        }
+    return(dtemp);
+    }
+
+
+/*
+** Scales a vector by a constant.
+** Jack Dongarra, linpack, 3/11/78.
+** UNROLLED version
+*/
+static void dscal_ur(int n,REAL da,REAL *dx,int incx)
+
+    {
+    int i,m,nincx;
+
+    if (n <= 0)
+        return;
+    if (incx != 1)
+        {
+
+        /* code for increment not equal to 1 */
+
+        nincx = n*incx;
+        for (i = 0; i < nincx; i = i + incx)
+            dx[i] = da*dx[i];
+        return;
+        }
+
+    /* code for increment equal to 1 */
+
+    m = n % 5;
+    if (m != 0)
+        {
+        for (i = 0; i < m; i++)
+            dx[i] = da*dx[i];
+        if (n < 5)
+            return;
+        }
+    for (i = m; i < n; i = i + 5)
+        {
+        dx[i] = da*dx[i];
+        dx[i+1] = da*dx[i+1];
+        dx[i+2] = da*dx[i+2];
+        dx[i+3] = da*dx[i+3];
+        dx[i+4] = da*dx[i+4];
+        }
+    }
+
+
+/*
+** Finds the index of element having max. absolute value.
+** Jack Dongarra, linpack, 3/11/78.
+*/
+static int idamax(int n,REAL *dx,int incx)
+
+    {
+    REAL dmax;
+    int i, ix, itemp;
+
+    if (n < 1)
+        return(-1);
+    if (n ==1 )
+        return(0);
+    if(incx != 1)
+        {
+
+        /* code for increment not equal to 1 */
+
+        ix = 1;
+        dmax = fabs((double)dx[0]);
+        ix = ix + incx;
+        for (i = 1; i < n; i++)
+            {
+            if(fabs((double)dx[ix]) > dmax)
+                {
+                itemp = i;
+                dmax = fabs((double)dx[ix]);
+                }
+            ix = ix + incx;
+            }
+        }
+    else
+        {
+
+        /* code for increment equal to 1 */
+
+        itemp = 0;
+        dmax = fabs((double)dx[0]);
+        for (i = 1; i < n; i++)
+            if(fabs((double)dx[i]) > dmax)
+                {
+                itemp = i;
+                dmax = fabs((double)dx[i]);
+                }
+        }
+    return (itemp);
+    }
+
+
+static REAL second(void)
+
+    {
+    return ((REAL)((REAL)clock()/(REAL)CLOCKS_PER_SEC));
+    }
+
+

--- a/examples/gcc/readme.md
+++ b/examples/gcc/readme.md
@@ -1,0 +1,71 @@
+# Exploration of GCC Optimization parameters
+In this example, the goal is to explore the effect of the
+basic GCC options used for compiling a target application. The metrics of
+interest in such a case will be the time needed for the compilation process, size of the generated binary file and the time needed for the execution of the compiled application.  
+
+## Design space definition
+Regarding the definition of the design space, two parameters (optimization `par_opt` and debug `par_dbg` options) are explored:
+
+- Optimization options parameter values:
+
+  - “-O”: The compiler tries to reduce code size and execution time, without
+    performing any optimizations that take a great deal of compilation time;
+
+  - “-O0”: Reduce compilation time and make debugging produce the expected
+    results. This is the default during GCC compilation;
+
+  - “-O1”: Optimizing compilation takes somewhat more time, and a lot more
+    memory for a large function;
+
+  - “-O2”: GCC performs nearly all supported optimizations that do not involve a
+    space-speed tradeoff. As compared to -O, this option usually increases both
+    compilation time and the performance of the generated code;
+
+  - “-O3”: Optimize yet more. -O3 turns on all optimizations specified by -O2
+    and also turns on the -finline-functions, -funswitch-loops,
+    -fpredictive-commoning, -fgcse-after-reload, -ftree-vectorize and
+    -fipa-cp-clone options;
+
+  - “-Os”: Optimize for size. -Os enables all -O2 optimizations that do not
+    typically increase code size. It also performs further optimizations
+    designed to reduce code size.
+
+- Debug options parameter values:
+
+  - “-g”: Produce debugging information in the operating system's native format
+    (stabs, COFF, XCOFF, or DWARF 2). GDB can work with this debugging
+    information. GCC allows you to use -g with -O. The shortcuts taken by
+    optimized code may occasionally produce surprising results: some variables
+    you declared may not exist at all; flow of control may briefly move where
+    you did not expect it; some statements may not be executed because they
+    compute constant results or their values were already at hand; some
+    statements may execute in different places because they were moved out of
+    loops.
+
+  - “ ”: None. The debugging options are not enabled.
+
+The __metrics__ contained with the system model are:
+
+  - Compilation Time: Time needed only for the compilation process;
+
+  - Execution Time: Time needed only to execute the compiled target application;
+
+  - Code Size: Size of the generated binary file.  
+
+The XML file that encodes this design space for MOST is *gcc_ds.xml*.  
+For convenience, we provide also a test C program (*linpack.c*) that can be compiled with gcc and can be used for benchmarking in this example. ([Reference](https://github.com/ereyes01/linpack))   
+
+## Interfacing with MOST
+Regarding the creation of a compliant interface with the **MOST** framework, we wrapped the GCC compilation process and the evaluation of the metrics within a python script (*gcc_most.py*), which is intended to be called as follows:  
+
+```shell
+python gcc_most.py --file=<target_filename>.c  \
+      --xml_system_configuration=<input_filename>.xml \
+      --xml_system_metrics=<output_filename>.xml
+```
+## Launch a full DSE with MOST
+The script *gcc_full_dse.scr* contains the commands to perform a full search with *MOST*, evaulating the *execution time* and *code size* as objectives of the optimization, while the compilation time is used only as an additional metric for analysis purposes.  
+This exploration can be launched with the following command:  
+
+    most -x gcc_ds.xml -f gcc_full_dse.scr  
+Befaure launching the example, please modify the *simulator_executable path* in *gcc_full_dse.xml*.


### PR DESCRIPTION
Added DLTZ1 and GCC exploration examples (and corresponding readmes) in the _examples_ folder, using the files provided by @vzaccaria.
In both of them, the provided MOST scripts perform a full search, as described in the [introductory section of the manual](https://github.com/vzaccaria/most/blob/master/docs/doc-most.md).  
Please note that the python scripts have been written in Python 3.